### PR TITLE
feat: add CLI arguments and add simple auth check

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ on a Amazon S3 compatible cloud storage provider, it will start a HTTP server on
 
 *Note*: The above example can be used to test against the Minio instance of the `docker-compose.yml` file found in the `dev`-directory.
 
-
 ### Configuration
 
 The server supports three kind of cloud storage, which are `s3`, `gcs` and `local`,
@@ -67,7 +66,24 @@ Flags:
       --s3.region=S3.REGION      The Amazon S3 region($AWS_S3_REGION_NAME).
       --version                  Show application version.
 ```
+## Configuring Turbo
 
+After you have started the server you need to change the configuration of Turbo
+to ensure it's pointing to our server for the API server. Currently, any of the
+login functionality is not implemented. You can adapt the `.turbo/config.json`-file
+in the root of your mono repo.
+
+```json
+{
+  "teamId": "team_blah",
+  "apiUrl": "http://127.0.0.1:8080"
+}
+```
+
+After this you should be able to run `turbo` e.g. `turbo run build --force` to
+force the generating of new cache artefacts and upload it to our server.
+
+Alternatively, you can also use the arguments `--api="http://127.0.0.1:8080" --token="xxxxxxxxxxxxxxxxx"`
 ## Developing
 
 In the `dev` directory you can find a docker compose file which starts, a Minio

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ on a Amazon S3 compatible cloud storage provider, it will start a HTTP server on
 ```bash
 ./tapico-turborepo-remote-cache --kind="s3" --s3.endpoint="http://127.0.0.1:9000" --s3.accessKeyId="minio" --s3.secretKey="miniosecretkey" --s3.region="eu-west-1" --turbo-token="your-turbo-token"
 ```
-
 *Note*: The above example can be used to test against the Minio instance of the `docker-compose.yml` file found in the `dev`-directory.
+
+At this time the server doesn't support running over HTTPS, you might want to consider
+using a load balancer to expose the server over HTTPS to the internet.
 
 ### Configuration
 
@@ -84,6 +86,11 @@ After this you should be able to run `turbo` e.g. `turbo run build --force` to
 force the generating of new cache artefacts and upload it to our server.
 
 Alternatively, you can also use the arguments `--api="http://127.0.0.1:8080" --token="xxxxxxxxxxxxxxxxx"`
+
+The `teamId` in `.tubrbo/config.json` or the `--team`-argument for `turbo` CLI is
+used to generate a bucket in the cloud storage provider, as the id might be an
+invalid name the team identifier a MD5 hash is generated and used as the bucket name.
+
 ## Developing
 
 In the `dev` directory you can find a docker compose file which starts, a Minio
@@ -100,6 +107,14 @@ export STORAGE_EMULATOR_HOST=http://localhost:9100
 
 The `STORAGE_EMULATOR_HOST` is used to activate a special code path in
 the Google Cloud Storage library for Go.
+
+*Tip*: If the Remote Cache is not working as expected, you can use an application
+like ProxyMan and force `turbo` CLI the application's HTTP proxy so you can get
+insight in the outgoing HTTP requests. To do this, you can run `turbo` the following
+way `HTTP_PROXY=192.168.1.98:9090 turbo run build`.
+
+You might need to use `HTTPS_PROXY` instead when the API server location is running
+over HTTPS instead of HTTP.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ The CLI tool currently supports the following targets for the cache artificats:
 
 ## Running the application
 
-You can execute this application by running:
+You can execute this application by running when you want to store your cache artefacts
+on a Amazon S3 compatible cloud storage provider, it will start a HTTP server on port 8080:
 
 ```bash
-./tapico-turborepo-remote-cache
+./tapico-turborepo-remote-cache --kind="s3" --s3.endpoint="http://127.0.0.1:9000" --s3.accessKeyId="minio" --s3.secretKey="miniosecretkey" --s3.region="eu-west-1" --turbo-token="your-turbo-token"
 ```
 
-This will start a web-server on port `8080`
+*Note*: The above example can be used to test against the Minio instance of the `docker-compose.yml` file found in the `dev`-directory.
+
 
 ### Configuration
 
@@ -28,16 +30,43 @@ the latter will store the cache artefects on the local file system on a relative
 The configuration is currently handled via environment variables, the following
 are available:
 
-  - CLOUD_PROVIDER_KIND: `s3`, `gcs` or `local`
-  - GOOGLE_CREDENTIALS_FILE: location the google credentials json file
-  - GOOGLE_PROJECT_ID: the project id
+  - `CLOUD_PROVIDER_KIND`: `s3`, `gcs` or `local`
+  - `GOOGLE_CREDENTIALS_FILE`: location the google credentials json file
+  - `GOOGLE_PROJECT_ID`: the project id
+  - `GOOGLE_ENDPOINT`: the endpoint to use for Google Cloud Storage (e.g. for emulator)
+  - `AWS_ENDPOINT`: the endpoint to connect to for Amazon S3
+  - `AWS_ACCESS_KEY_ID`: the Amazon acces key id
+  - `AWS_SECRET_ACCESS_KEY`: the Amazon secret access key
+  - `AWS_S3_REGION_NAME`: the region for Amazon S3
+  - `CLOUD_SECURE`: whether the endpoint is secure (https) or not, can be `true` or `false`
+  - `CLOUD_FILESYSTEM_PATH`: the relative path to the file system
+  - `TURBO_TOKEN`: comma seperated list of accepted TURBO_TOKENS
 
-  - AWS_ENDPOINT: the endpoint to connect to for Amazon S3
-  - AWS_ACCESS_KEY_ID: the Amazon acces key id
-  - AWS_SECRET_ACCESS_KEY: the Amazon secret access key
-  - AWS_S3_REGION_NAME: the region for Amazon S3
-  - CLOUD_SECURE: whether the endpoint is secure (https) or not, can be `true` or `false`
-  - CLOUD_FILESYSTEM_PATH: the relative path to the file system
+Alternatively, you can also use the CLI arguments:
+
+```bash
+usage: tapico-turborepo-remote-cache --turbo-token=TURBO-TOKEN [<flags>]
+
+Flags:
+      --help                     Show context-sensitive help (also try --help-long and --help-man).
+  -v, --verbose                  Verbose mode.
+      --kind="s3"                Kind of storage provider to use (s3, gcp, local). ($CLOUD_PROVIDER_KIND)
+      --secure                   Enable secure access (or HTTPs endpoints).
+      --turbo-token=TURBO-TOKEN  The comma separated list of TURBO_TOKEN that the server should accept ($TURBO_TOKEN)
+      --google.endpoint="http://127.0.0.1:9000"
+                                 API Endpoint of cloud storage provide to use ($GOOGLE_ENDPOINT)
+      --google.project-id=GOOGLE.PROJECT-ID
+                                 The project id relevant for Google Cloud Storage ($GOOGLE_PROJECT_ID).
+      --local.project-id=LOCAL.PROJECT-ID
+                                 The relative path to storage the cache artefacts when 'local' is enabled ($CLOUD_FILESYSTEM_PATH).
+      --s3.endpoint=S3.ENDPOINT  The endpoint to use to connect to a Amazon S3 compatible cloud storage provider ($AWS_ENDPOINT).
+      --s3.accessKeyId=S3.ACCESSKEYID
+                                 The Amazon S3 Access Key Id ($AWS_ACCESS_KEY_ID).
+      --s3.secretKey=S3.SECRETKEY
+                                 The Amazon S3 secret key ($AWS_SECRET_ACCESS_KEY).
+      --s3.region=S3.REGION      The Amazon S3 region($AWS_S3_REGION_NAME).
+      --version                  Show application version.
+```
 
 ## Developing
 

--- a/gcs/config.go
+++ b/gcs/config.go
@@ -20,6 +20,7 @@ const (
 	// The service account json blob.
 	ConfigJSON      = "json"
 	ConfigProjectId = "project_id"
+	ConfigEndpoint  = "endpoint"
 	ConfigScopes    = "scopes"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.17
 require (
 	cloud.google.com/go v0.97.0 // indirect
 	cloud.google.com/go/storage v1.18.2 // indirect
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a // indirect
 	github.com/aws/aws-sdk-go v1.40.45 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
@@ -36,4 +38,5 @@ require (
 	google.golang.org/genproto v0.0.0-20211016002631-37fc39342514 // indirect
 	google.golang.org/grpc v1.40.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,10 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a h1:E/8AP5dFtMhl5KPJz66Kt9G0n+7Sn41Fy1wv9/jHOrc=
+github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aws/aws-sdk-go v1.23.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.40.45 h1:QN1nsY27ssD/JmW4s83qmSb+uL6DG4GmCDzjmJB4xUI=
@@ -606,6 +610,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/main.go
+++ b/main.go
@@ -423,7 +423,8 @@ func initTracer() *sdktrace.TracerProvider {
 func main() {
 	kingpin.Version("0.0.1")
 	kingpin.Parse()
-	fmt.Printf("projectID: %s kind: %s localStoragePath: %s aws.endpoint: %s gogle.endpoint: %s", *googleProjectID, *kind, *localStoragePath, *awsEndpoint, *googleEndpoint)
+
+	fmt.Printf("projectID: %s kind: %s localStoragePath: %s aws.endpoint: %s google.endpoint: %s", *googleProjectID, *kind, *localStoragePath, *awsEndpoint, *googleEndpoint)
 
 	// Logfmt is a structured, key=val logging format that is easy to read and parse
 	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var (
 	verbose = kingpin.Flag("verbose", "Verbose mode.").Short('v').Bool()
 	kind    = kingpin.Flag("kind", "Kind of storage provider to use (s3, gcp, local). ($CLOUD_PROVIDER_KIND)").Default("s3").Envar("CLOUD_PROVIDER_KIND").String()
 
-	useSecure = kingpin.Flag("secure", "Enable secure access (or HTTPs endpoints).").Bool()
+	useSecure = kingpin.Flag("secure", "Enable secure access (or HTTPs endpoints).").Envar("CLOUD_SECURE").Bool()
 
 	allowedTurboTokens = kingpin.Flag("turbo-token", "The comma separated list of TURBO_TOKEN that the server should accept ($TURBO_TOKEN)").Envar("TURBO_TOKEN").Required().String()
 

--- a/main.go
+++ b/main.go
@@ -40,36 +40,36 @@ var logger log.Logger
 
 var (
 	app     = kingpin.New("tapico-turborepo-remote-cache", "A tool to work with Vercel Turborepo to upload/retrieve cache artefacts to/from popular cloud providers")
-	verbose = kingpin.Flag("verbose", "Verbose mode.").Short('v').Bool()
-	kind    = kingpin.Flag("kind", "Kind of storage provider to use (s3, gcp, local). ($CLOUD_PROVIDER_KIND)").Default("s3").Envar("CLOUD_PROVIDER_KIND").String()
+	verbose = app.Flag("verbose", "Verbose mode.").Short('v').Bool()
+	kind    = app.Flag("kind", "Kind of storage provider to use (s3, gcp, local). ($CLOUD_PROVIDER_KIND)").Default("s3").Envar("CLOUD_PROVIDER_KIND").String()
 
-	useSecure = kingpin.Flag("secure", "Enable secure access (or HTTPs endpoints).").Envar("CLOUD_SECURE").Bool()
+	useSecure = app.Flag("secure", "Enable secure access (or HTTPs endpoints).").Envar("CLOUD_SECURE").Bool()
 
-	allowedTurboTokens = kingpin.Flag("turbo-token", "The comma separated list of TURBO_TOKEN that the server should accept ($TURBO_TOKEN)").Envar("TURBO_TOKEN").Required().String()
+	allowedTurboTokens = app.Flag("turbo-token", "The comma separated list of TURBO_TOKEN that the server should accept ($TURBO_TOKEN)").Envar("TURBO_TOKEN").Required().String()
 
-	googleEndpoint = kingpin.Flag("google.endpoint", "API Endpoint of cloud storage provide to use ($GOOGLE_ENDPOINT)").Default("http://127.0.0.1:9000").Envar("GOOGLE_ENDPOINT").String()
+	googleEndpoint = app.Flag("google.endpoint", "API Endpoint of cloud storage provide to use ($GOOGLE_ENDPOINT)").Default("http://127.0.0.1:9000").Envar("GOOGLE_ENDPOINT").String()
 
-	googleProjectID = kingpin.Flag(
+	googleProjectID = app.Flag(
 		"google.project-id", "The project id relevant for Google Cloud Storage ($GOOGLE_PROJECT_ID).",
 	).Envar("GOOGLE_PROJECT_ID").String()
 
-	localStoragePath = kingpin.Flag(
+	localStoragePath = app.Flag(
 		"local.project-id", "The relative path to storage the cache artefacts when 'local' is enabled ($CLOUD_FILESYSTEM_PATH).",
 	).Envar("CLOUD_FILESYSTEM_PATH").String()
 
-	awsEndpoint = kingpin.Flag(
+	awsEndpoint = app.Flag(
 		"s3.endpoint", "The endpoint to use to connect to a Amazon S3 compatible cloud storage provider ($AWS_ENDPOINT).",
 	).Envar("AWS_ENDPOINT").String()
 
-	awsAccessKeyID = kingpin.Flag(
+	awsAccessKeyID = app.Flag(
 		"s3.accessKeyId", "The Amazon S3 Access Key Id ($AWS_ACCESS_KEY_ID).",
 	).Envar("AWS_ACCESS_KEY_ID").String()
 
-	awsSecretKey = kingpin.Flag(
+	awsSecretKey = app.Flag(
 		"s3.secretKey", "The Amazon S3 secret key ($AWS_SECRET_ACCESS_KEY).",
 	).Envar("AWS_SECRET_ACCESS_KEY").String()
 
-	awsRegionName = kingpin.Flag(
+	awsRegionName = app.Flag(
 		"s3.region", "The Amazon S3 region($AWS_S3_REGION_NAME).",
 	).Envar("AWS_S3_REGION_NAME").String()
 )
@@ -422,7 +422,7 @@ func initTracer() *sdktrace.TracerProvider {
 
 func main() {
 	kingpin.Version("0.0.1")
-	kingpin.Parse()
+	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	fmt.Printf("projectID: %s kind: %s localStoragePath: %s aws.endpoint: %s google.endpoint: %s", *googleProjectID, *kind, *localStoragePath, *awsEndpoint, *googleEndpoint)
 


### PR DESCRIPTION
Introducing CLI arguments to pass the necessary arguments via
environment variables or via CLI arguments

Added new CLI argument named `--turbo-token` that accepts a comma-separated
list of TURBO_TOKEN that the server should accept, if its not listed it
will return a 401 Unauthorized header