### PR TITLE
ci: improve release github workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17.5
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ tapico-turborepo-remote-cache
 
 # Development data
 dev/data/
+dist
+.env


### PR DESCRIPTION
Increase the expected Go version to 1.17.5 as used in local environment

Add `dist`-directory to the `.gitignore` file