### PR TITLE
Fixes teamId query param handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ to ensure it's pointing to our server for the API server. Currently, any of the
 login functionality is not implemented. You can adapt the `.turbo/config.json`-file
 in the root of your mono repo.
 
+NOTE: You **don't** have to run `turbo login` step.
+
 ```json
 {
   "teamId": "team_blah",
@@ -82,12 +84,18 @@ in the root of your mono repo.
 }
 ```
 
+NOTE: `teamId` must start with "team_".
+
 After this you should be able to run `turbo` e.g. `turbo run build --force` to
 force the generating of new cache artefacts and upload it to our server.
 
 Alternatively, you can also use the arguments `--api="http://127.0.0.1:8080" --token="xxxxxxxxxxxxxxxxx"`
 
-The `teamId` in `.tubrbo/config.json` or the `--team`-argument for `turbo` CLI is
+Token can also be specified as enviroment variable `TURBO_TOKEN=xxxxx`, for example: `TURBO_TOKEN=xxxx turbo run build`
+
+NOTE: CLI argument `--team` is not supported, please only use `teamId` from `.turbo/config.json`.
+
+The `teamId` in `.turbo/config.json` is
 used to generate a bucket in the cloud storage provider, as the id might be an
 invalid name the team identifier a MD5 hash is generated and used as the bucket name.
 

--- a/main.go
+++ b/main.go
@@ -298,7 +298,7 @@ func readCacheItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	query := r.URL.Query()
-	if !query.Has("teamID") {
+	if !query.Has("teamId") {
 		w.WriteHeader(http.StatusPreconditionFailed)
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write([]byte(`{"error":{"message":"teamID is missing","code":"required"}}`))
@@ -308,7 +308,7 @@ func readCacheItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	teamID := query.Get("teamID")
+	teamID := query.Get("teamId")
 	sanitisedteamID := GetBucketName(teamID)
 	logger.Log("message", fmt.Sprintf("received the following teamID=%s sanitisedteamID=%s", teamID, sanitisedteamID))
 
@@ -333,21 +333,20 @@ func readCacheItem(w http.ResponseWriter, r *http.Request) {
 
 	// Attempt to read the file contents of the artificats
 	defer fileReference.Close()
-	fileBuffer := make([]byte, 4)
-	n, err := fileReference.Read(fileBuffer)
-	if err != nil {
-		logger.Log(err)
-		stdlog.Fatal(err)
-	}
-
-	logger.Log("message", fmt.Sprintf("total size of buffer=%d", n))
 
 	w.WriteHeader((http.StatusOK))
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Accept, Content-Type")
 	w.Header().Set("Access-Control-Allow-Methods", "OPTIONS, GET, POST, PUT, PATCH, DELETE")
-	w.Write(fileBuffer)
+
+	n, err := io.Copy(w, fileReference)
+	if err != nil {
+		logger.Log(err)
+		stdlog.Fatal(err)
+	}
+
+	logger.Log("message", fmt.Sprintf("total size of buffer=%d", n))
 }
 
 func writeCacheItem(w http.ResponseWriter, r *http.Request) {
@@ -380,7 +379,7 @@ func writeCacheItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	teamID := query.Get("teamID")
+	teamID := query.Get("teamId")
 	sanitisedteamID := GetBucketName(teamID)
 	logger.Log("message", "received the following", "teamID", teamID, "sanitisedteamID", sanitisedteamID)
 


### PR DESCRIPTION
Hi,

Thanks for starting the project, I was playing around with the server and discovered couple of bugs along the way and this PR should fix them.

First issue is with teamId query param it should be teamId instead of teamID, here is the reference from the client https://github.com/vercel/turborepo/blob/main/cli/internal/client/client.go#L76

Second issue is with artifact download, I'm not a go expert, but it seems to me that current code is only writing first 5 bytes, so I used io.Copy to copy the whole stream to the output.

I also added some notes in the docs which I had trouble with.

Let me know what you think.

Cheeers!